### PR TITLE
ブロックを破壊したプレイヤーにDestroyBlockParticleが送られない仕様の修正

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1635,7 +1635,7 @@ class Level implements ChunkManager, Metadatable{
 		if($createParticles){
 			$players = $this->getChunkPlayers($target->x >> 4, $target->z >> 4);
 			if($player !== null){
-				unset($players[$player->getLoaderId()]);
+				//unset($players[$player->getLoaderId()]);
 			}
 
 			$this->addParticle(new DestroyBlockParticle($target->add(0.5), $target), $players);


### PR DESCRIPTION
Level.phpの1638行目をコメントアウトすることにより、ブロック破壊したプレイヤーにもDestroyBlockParticleが送られます