### PR TITLE
fix duplicate player name in player list.

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2245,7 +2245,10 @@ class Server{
 		$pk = new PlayerListPacket();
 		$pk->type = PlayerListPacket::TYPE_ADD;
 		$pk->entries[] = [$uuid, $entityId, $name, $skinId, $skinData];
-		Server::broadcastPacket($players === null ? $this->playerList : $players, $pk);
+
+		Server::broadcastPacket(array_filter($players === null ? $this->playerList : $players, function(Player $p) use ($uuid) {
+            return $p->getUniqueId() != $uuid;
+        }), $pk);
 	}
 
 	public function removePlayerListData(UUID $uuid, array $players = null){


### PR DESCRIPTION
プレイヤーリストで自分自身のプレイヤー名が重複表示されるバグを修正。自分自身のプレイヤー名は、クライアント側でプレイヤーリストの先頭に追加表示しているように見受けられるため、サーバー側からプレイヤーリストのデータをクライアントに送信する際に、送信先のプレイヤーを除去することで重複表示しないように修正。
