### PR TITLE
fix ClassNotFoundException: "Class pocketmine\level\LongTag not found…

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -93,6 +93,7 @@ use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
+use pocketmine\nbt\tag\LongTag;
 use pocketmine\network\protocol\DataPacket;
 use pocketmine\network\protocol\FullChunkDataPacket;
 use pocketmine\network\protocol\LevelEventPacket;


### PR DESCRIPTION
fix ClassNotFoundException: "Class pocketmine\level\LongTag not found" (EXCEPTION) in "/src/spl/BaseClassLoader" at line 144
