### PR TITLE
CreativeInventory操作

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1960,16 +1960,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			unset($this->personalCreativeItems[$index]);
 		}
 	}
-
-	public function getCreativeItemIndex(Item $item) : int{
-		foreach($this->personalCreativeItems as $i => $d){
-			if($item->equals($d, !$item->isTool())){
-				return $i;
-			}
-		}
-
-		return -1;
-	}
 	
 	public function tryAuthenticate(){
 		$pk = new PlayStatusPacket();

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -295,6 +295,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected $deviceModel;
 	protected $os;
 
+	/** @var Item[] */
+	protected $personalCreativeItems = [];
+	
 	public function getLeaveMessage(){
 		return new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.left", [
 			$this->getDisplayName()
@@ -1939,6 +1942,35 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->tryAuthenticate();
 	}
 
+	public function clearCreativeItems(){
+		$this->personalCreativeItems = [];
+	}
+
+	public function getCreativeItems() : array{
+		return $this->personalCreativeItems;
+	}
+
+	public function addCreativeItem(Item $item){
+		$this->personalCreativeItems[] = Item::get($item->getId(), $item->getDamage());
+	}
+
+	public function removeCreativeItem(Item $item){
+		$index = $this->getCreativeItemIndex($item);
+		if($index !== -1){
+			unset($this->personalCreativeItems[$index]);
+		}
+	}
+
+	public function getCreativeItemIndex(Item $item) : int{
+		foreach($this->personalCreativeItems as $i => $d){
+			if($item->equals($d, !$item->isTool())){
+				return $i;
+			}
+		}
+
+		return -1;
+	}
+	
 	public function tryAuthenticate(){
 		$pk = new PlayStatusPacket();
 		$pk->status = PlayStatusPacket::LOGIN_SUCCESS;

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -498,8 +498,10 @@ class PlayerInventory extends BaseInventory{
 		$pk = new ContainerSetContentPacket();
 		$pk->windowid = ContainerSetContentPacket::SPECIAL_CREATIVE;
 		if($this->getHolder()->getGamemode() === Player::CREATIVE){
-			foreach(Item::getCreativeItems() as $i => $item){
-				$pk->slots[$i] = clone $item;
+			$creativeitems = $this->getHolder()->getCreativeItems();
+			if(empty($creativeitems)) $creativeitems = Item::getCreativeItems();
+			foreach($creativeitems as $i => $item){
+				$pk->slots[$i] = $item;
 			}
 		}
 		$this->getHolder()->dataPacket($pk);


### PR DESCRIPTION
プレイヤーのクリエイティブインベントリを$player->addCreativeItem()で操作できるようにしました
何もしなければItem::getCreativeItems()が適用されます
PlayerLoginEventから$player->addCreativeItem()して貰えれば入室時に適用されます
それ以外からする場合、ゲームモードを一度Survivalに戻しCreativeにする必要があります