### PR TITLE
Fix console spams because of vines

### DIFF
--- a/src/pocketmine/block/Vine.php
+++ b/src/pocketmine/block/Vine.php
@@ -19,6 +19,8 @@
  *
 */
 
+declare(strict_types=1);
+
 namespace pocketmine\block;
 
 use pocketmine\entity\Entity;
@@ -26,9 +28,14 @@ use pocketmine\item\Item;
 use pocketmine\item\Tool;
 use pocketmine\level\Level;
 use pocketmine\math\AxisAlignedBB;
+use pocketmine\math\Vector3;
 use pocketmine\Player;
 
 class Vine extends Transparent{
+	const FLAG_SOUTH = 0x01;
+	const FLAG_WEST = 0x02;
+	const FLAG_NORTH = 0x04;
+	const FLAG_EAST = 0x08;
 
 	protected $id = self::VINE;
 
@@ -75,7 +82,7 @@ class Vine extends Transparent{
 
 		$flag = $this->meta > 0;
 
-		if(($this->meta & 0x02) > 0){
+		if(($this->meta & self::FLAG_WEST) > 0){
 			$f4 = max($f4, 0.0625);
 			$f1 = 0;
 			$f2 = 0;
@@ -85,7 +92,7 @@ class Vine extends Transparent{
 			$flag = true;
 		}
 
-		if(($this->meta & 0x08) > 0){
+		if(($this->meta & self::FLAG_EAST) > 0){
 			$f1 = min($f1, 0.9375);
 			$f4 = 1;
 			$f2 = 0;
@@ -95,7 +102,7 @@ class Vine extends Transparent{
 			$flag = true;
 		}
 
-		if(($this->meta & 0x01) > 0){
+		if(($this->meta & self::FLAG_SOUTH) > 0){
 			$f3 = min($f3, 0.9375);
 			$f6 = 1;
 			$f1 = 0;
@@ -105,7 +112,7 @@ class Vine extends Transparent{
 			$flag = true;
 		}
 
-		if(!$flag and $this->getSide(1)->isSolid()){
+		if(!$flag and $this->getSide(Vector3::SIDE_UP)->isSolid()){
 			$f2 = min($f2, 0.9375);
 			$f5 = 1;
 			$f1 = 0;
@@ -126,12 +133,13 @@ class Vine extends Transparent{
 
 
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
+		//TODO: multiple sides
 		if($target->isSolid()){
 			$faces = [
-				2 => 1,
-				3 => 4,
-				4 => 8,
-				5 => 2,
+				2 => self::FLAG_SOUTH,
+				3 => self::FLAG_NORTH,
+				4 => self::FLAG_EAST,
+				5 => self::FLAG_WEST,
 			];
 			if(isset($faces[$face])){
 				$this->meta = $faces[$face];
@@ -147,11 +155,16 @@ class Vine extends Transparent{
 	public function onUpdate($type){
 		if($type === Level::BLOCK_UPDATE_NORMAL){
 			$sides = [
+				1 => 3,
 				2 => 4,
-				3 => 1,
 				4 => 2,
-				5 => 8
+				8 => 5
 			];
+
+			if(!isset($sides[$this->meta])){
+				return false; //TODO: remove this once placing on multiple sides is supported (these are bitflags, not actual meta values
+			}
+
 			if(!$this->getSide($sides[$this->meta])->isSolid()){ //Replace with common break method
 				$this->level->useBreakOn($this);
 				return Level::BLOCK_UPDATE_NORMAL;
@@ -164,7 +177,7 @@ class Vine extends Transparent{
 	public function getDrops(Item $item){
 		if($item->isShears()){
 			return [
-				[$this->id, 0, 1],
+				Item::get($this->getId(), 0, 1)
 			];
 		}else{
 			return [];


### PR DESCRIPTION
## Have you tested?
- [x] I have tested.
- [ ] I haven't tested.

This fixes this console spam (from pmmp,i found that it happens also on bluelight)

Bluelight:

[22:27:52] [Server thread/INFO]: 00GuyExtremeGame[/127.0.0.1:40739] logged in with entity id 1 at (Creative1, 136.9265, 4.5625, 109.0049)
[22:27:54] [Server thread/INFO]: 00GuyExtremeGame joined the game
[22:28:35] [Server thread/CRITICAL]: ErrorException: "Undefined offset: 8" (EXCEPTION) in "/src/pocketmine/block/Vine" at line 155
[06:28:35] [RakLibServer thread/NOTICE]: Blocked 127.0.0.1 for 5 seconds
[22:28:40] [Server thread/CRITICAL]: ErrorException: "Undefined offset: 8" (EXCEPTION) in "/src/pocketmine/block/Vine" at line 155
[06:28:40] [RakLibServer thread/NOTICE]: Blocked 127.0.0.1 for 5 seconds
[22:28:40] [Server thread/CRITICAL]: ErrorException: "Undefined offset: 8" (EXCEPTION) in "/src/pocketmine/block/Vine" at line 155

